### PR TITLE
Fix: Resolve KeyError and UserWarning in real-time prediction

### DIFF
--- a/feature_extractor.py
+++ b/feature_extractor.py
@@ -72,9 +72,10 @@ def process_packets(packets, laptop_ip, interval):
     """
     data = []
     for pkt in packets:
-        record = {'timestamp': pkt.time, 'length': len(pkt)}
+        record = {'timestamp': pkt.time, 'length': len(pkt), 'is_from_laptop': 0}
         if IP in pkt:
-            record['is_from_laptop'] = 1 if pkt[IP].src == laptop_ip else 0
+            if pkt[IP].src == laptop_ip:
+                record['is_from_laptop'] = 1
         data.append(record)
 
     if not data:

--- a/realtime_predictor.py
+++ b/realtime_predictor.py
@@ -93,7 +93,10 @@ def main():
                 if has_tcp:
                     # --- Make new prediction for the NEXT interval ---
                     ts_data = np.array(list(data_queue))
-                    scaled_ts_data = scaler.transform(ts_data)
+
+                    # Convert to DataFrame to preserve feature names for the scaler
+                    ts_df = pd.DataFrame(ts_data, columns=features_to_use)
+                    scaled_ts_data = scaler.transform(ts_df)
 
                     model_input = [
                         np.expand_dims(scaled_ts_data, axis=0),


### PR DESCRIPTION
This commit addresses two issues identified during real-time prediction:

1.  **Fix `KeyError` for `is_from_laptop`:** A `KeyError` would occur if a sniffing interval captured only non-IP packets (e.g., ARP), because the `is_from_laptop` column would not be created in the resulting DataFrame. This is fixed by ensuring this key is always initialized for every packet record in `feature_extractor.py`.

2.  **Suppress `UserWarning` from StandardScaler:** A `UserWarning` was displayed because the `StandardScaler` was fitted on a DataFrame with feature names but was used for transformation on a raw NumPy array without names. The logic in `realtime_predictor.py` has been updated to reconstruct a DataFrame with the correct column names before scaling, which silences the warning and is better practice.