### PR TITLE
Fix: Resolve MAPE calculation bug and add bias correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ The real-time predictor now **requires you to specify the activity** so the mode
     ```bash
     # Example for predicting 'gaming' traffic
     # Note: Requires admin/sudo privileges
-    sudo python realtime_predictor.py --ip 192.168.1.103 --iface wlan0 --activity gaming
+    sudo python realtime_predictor.py --ip 192.168.1.103 --iface wlan0 --activity gaming --bias-correction 0.005
     ```
     - Replace `YOUR_IP`, `wlan0`, and `gaming` with your specific configuration. The activity name must be one of the labels found during the parsing step (and present in `activity_map.json`).
+    - The optional `--bias-correction` argument allows you to manually subtract a small constant value (e.g., 0.005 for 5ms) from the model's prediction to correct for any consistent positive bias.
 
 The script will open a live plot and start predicting congestion, using the context you provided to make a more intelligent forecast.
 


### PR DESCRIPTION
This commit addresses two issues identified during real-time prediction:

1.  **Fix MAPE Calculation:** The MAPE calculation would produce extremely large, nonsensical values when the actual RTT was zero. The logic is now fixed to only include percentage errors in the rolling average when the actual RTT is non-zero. This provides a stable and meaningful error metric.

2.  **Add Manual Bias Correction:** A new command-line argument, `--bias-correction`, has been added to `realtime_predictor.py`. This allows the user to subtract a small, constant value from the model's raw prediction, providing a manual calibration tool to correct for any consistent positive bias observed in the model's output. The result is clipped at zero to prevent negative RTT predictions.

The `README.md` has been updated to document the new argument.