### PR TITLE
fix: Ensure packet loss timestamps are numeric

### DIFF
--- a/feature_extractor.py
+++ b/feature_extractor.py
@@ -111,7 +111,8 @@ def process_packets(packets, laptop_ip, interval):
     df['lost_packet'] = 0
     if lost_packets_ts:
         # For each lost packet, find the closest timestamp in the main df and mark it as lost
-        lost_times = pd.to_datetime(lost_packets_ts, unit='s')
+        numeric_lost_ts = pd.to_numeric(pd.Series(lost_packets_ts), errors='coerce').dropna()
+        lost_times = pd.to_datetime(numeric_lost_ts, unit='s')
         # Use searchsorted to find insertion points, which corresponds to nearest index
         indices = df['timestamp'].searchsorted(lost_times)
         # To avoid index out of bounds


### PR DESCRIPTION
A previous commit fixed a `ValueError` for RTT timestamps but missed a similar issue in the packet loss calculation logic.

This commit ensures that `lost_packets_ts` are also converted to a numeric type before being passed to `pd.to_datetime`, fully resolving the timestamp conversion bug.