### PR TITLE
Fix: Handle non-numeric timestamp values in feature_extractor

### DIFF
--- a/feature_extractor.py
+++ b/feature_extractor.py
@@ -99,6 +99,8 @@ def process_packets(packets, laptop_ip, interval):
 
     if rtt_records:
         rtt_df = pd.DataFrame(rtt_records)
+        rtt_df['timestamp'] = pd.to_numeric(rtt_df['timestamp'], errors='coerce')
+        rtt_df.dropna(subset=['timestamp'], inplace=True)
         rtt_df['timestamp'] = pd.to_datetime(rtt_df['timestamp'], unit='s')
         df = pd.merge_asof(df.sort_values('timestamp'), rtt_df.sort_values('timestamp'), on='timestamp', direction='backward')
         df['rtt'] = df['rtt'].ffill().fillna(0)


### PR DESCRIPTION
The script was failing with a `ValueError` because the `pd.to_datetime` function was called with a non-numeric value while using the `unit='s'` parameter. This occurred when processing RTT data from pcap files.

This commit fixes the issue by explicitly converting the 'timestamp' column in the `rtt_df` DataFrame to a numeric type using `pd.to_numeric` before attempting to convert it to a datetime object. This ensures that any string representations of floating-point timestamps are correctly handled, making the script more robust.